### PR TITLE
Add example config file

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,0 +1,2 @@
+auth:
+    token: 'discord-token-here'


### PR DESCRIPTION
Adds an example basic config file that can be pattern-matched to. For now, the only configuration option is `auth.token`, but I imagine creating more once we pick up speed!